### PR TITLE
Added hotkey support on switching audio device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ x64/
 .vs
 .vscode/
 build/
+/build_new

--- a/Sources/AudioSwitcherStreamDeckPlugin.cpp
+++ b/Sources/AudioSwitcherStreamDeckPlugin.cpp
@@ -29,6 +29,19 @@ LICENSE file.
 
 #include "audio_json.h"
 
+// Add Windows and macOS specific includes
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <ApplicationServices/ApplicationServices.h>
+#include <unistd.h>
+#endif
+
+// Remove custom file logging
+#include <ctime>
+#include <fstream>
+#include <iostream>
+
 using namespace FredEmmott::Audio;
 using json = nlohmann::json;
 
@@ -57,6 +70,7 @@ bool FillAudioDeviceInfo(AudioDeviceInfo& di) {
 }// namespace
 
 AudioSwitcherStreamDeckPlugin::AudioSwitcherStreamDeckPlugin() {
+  // Remove FileLog calls
 #ifdef _MSC_VER
   CoInitializeEx(
     NULL, COINIT_MULTITHREADED);// initialize COM for the main thread
@@ -104,42 +118,44 @@ void AudioSwitcherStreamDeckPlugin::KeyUpForAction(
   if (!inPayload.contains("settings")) {
     return;
   }
+
   auto& settings = mButtons[inContext].settings;
   settings = inPayload.at("settings");
+
   FillButtonDeviceInfo(inContext);
 
   const auto state = EPLJSONUtils::GetIntByName(inPayload, "state");
+
   // this looks inverted - but if state is 0, we want to move to state 1, so
   // we want the secondary devices. if state is 1, we want state 0, so we want
   // the primary device
   const auto deviceID = (state != 0 || inAction == SET_ACTION_ID)
     ? settings.VolatilePrimaryID()
     : settings.VolatileSecondaryID();
+
   if (deviceID.empty()) {
-    ESDDebug("Doing nothing, no device ID");
     return;
   }
 
   const auto deviceState = GetAudioDeviceState(deviceID);
   if (deviceState != AudioDeviceState::CONNECTED) {
-    if (inAction == SET_ACTION_ID) {
-      mConnectionManager->SetState(1, inContext);
-    }
     mConnectionManager->ShowAlertForContext(inContext);
-    return;
-  }
-
-  if (
-    inAction == SET_ACTION_ID
-    && deviceID == GetDefaultAudioDeviceID(settings.direction, settings.role)) {
-    // We already have the correct device, undo the state change
-    mConnectionManager->SetState(state, inContext);
-    ESDDebug("Already set, nothing to do");
     return;
   }
 
   ESDDebug("Setting device to {}", deviceID);
   SetDefaultAudioDeviceID(settings.direction, settings.role, deviceID);
+
+  // Determine which hotkey to use based on which device we're switching to
+  const HotkeyConfig& hotkeyToUse = (state != 0 || inAction == SET_ACTION_ID)
+    ? settings.primaryHotkey
+    : settings.secondaryHotkey;
+
+  // Trigger hotkey if enabled
+  if (hotkeyToUse.enabled && !hotkeyToUse.keyCode.empty()) {
+    ESDDebug("Triggering hotkey: {}", hotkeyToUse.keyCode);
+    TriggerHotkey(hotkeyToUse);
+  }
 }
 
 void AudioSwitcherStreamDeckPlugin::WillAppearForAction(
@@ -263,4 +279,276 @@ void AudioSwitcherStreamDeckPlugin::DidReceiveSettings(
   const json& inPayload,
   const std::string& inDeviceID) {
   WillAppearForAction(inAction, inContext, inPayload, inDeviceID);
+}
+
+// Add the TriggerHotkey function
+void TriggerHotkey(const HotkeyConfig& hotkey) {
+  if (!hotkey.enabled || hotkey.keyCode.empty()) {
+    return;
+  }
+
+#ifdef _WIN32
+  INPUT inputs[10] = {};// Maximum 5 keys (4 modifiers + 1 key) plus releases
+  int inputCount = 0;
+
+  // Press modifiers
+  if (hotkey.ctrl) {
+    inputs[inputCount].type = INPUT_KEYBOARD;
+    inputs[inputCount].ki.wVk = VK_CONTROL;
+    inputCount++;
+  }
+  if (hotkey.alt) {
+    inputs[inputCount].type = INPUT_KEYBOARD;
+    inputs[inputCount].ki.wVk = VK_MENU;
+    inputCount++;
+  }
+  if (hotkey.shift) {
+    inputs[inputCount].type = INPUT_KEYBOARD;
+    inputs[inputCount].ki.wVk = VK_SHIFT;
+    inputCount++;
+  }
+  if (hotkey.win) {
+    inputs[inputCount].type = INPUT_KEYBOARD;
+    inputs[inputCount].ki.wVk = VK_LWIN;
+    inputCount++;
+  }
+
+  // Press the key
+  inputs[inputCount].type = INPUT_KEYBOARD;
+  // Convert string key code to virtual key code
+  WORD vkCode = 0;
+
+  if (hotkey.keyCode.length() == 1) {
+    // Convert single character to virtual key code
+    SHORT scanCode = VkKeyScanA(hotkey.keyCode[0]);
+    if (scanCode != -1) {
+      vkCode = LOBYTE(scanCode);
+    }
+  } else if (
+    hotkey.keyCode.substr(0, 1) == "F" && hotkey.keyCode.length() <= 3) {
+    // Handle function keys F1-F24
+    try {
+      int fKey = std::stoi(hotkey.keyCode.substr(1));
+      if (fKey >= 1 && fKey <= 24) {
+        vkCode = VK_F1 + (fKey - 1);
+      }
+    } catch (const std::exception& e) {
+      // Error parsing function key
+    }
+  } else {
+    // Handle named keys using a switch for cleaner code
+    // First check for special key names
+    if (hotkey.keyCode == "SPACE") {
+      vkCode = VK_SPACE;
+    } else if (hotkey.keyCode == "ENTER" || hotkey.keyCode == "RETURN") {
+      vkCode = VK_RETURN;
+    } else if (hotkey.keyCode == "ESCAPE" || hotkey.keyCode == "ESC") {
+      vkCode = VK_ESCAPE;
+    } else if (hotkey.keyCode == "TAB") {
+      vkCode = VK_TAB;
+    } else {
+      // For single letters and numbers, use a switch statement
+      if (hotkey.keyCode.length() == 1) {
+        char key = hotkey.keyCode[0];
+        vkCode = key;// ASCII values map directly to VK codes for A-Z and 0-9
+      } else {
+        // For named letter keys (e.g., "A", "B")
+        switch (hotkey.keyCode[0]) {
+          case 'A':
+            vkCode = 'A';
+            break;
+          case 'B':
+            vkCode = 'B';
+            break;
+          case 'C':
+            vkCode = 'C';
+            break;
+          case 'D':
+            vkCode = 'D';
+            break;
+          case 'E':
+            vkCode = 'E';
+            break;
+          case 'F':
+            vkCode = 'F';
+            break;
+          case 'G':
+            vkCode = 'G';
+            break;
+          case 'H':
+            vkCode = 'H';
+            break;
+          case 'I':
+            vkCode = 'I';
+            break;
+          case 'J':
+            vkCode = 'J';
+            break;
+          case 'K':
+            vkCode = 'K';
+            break;
+          case 'L':
+            vkCode = 'L';
+            break;
+          case 'M':
+            vkCode = 'M';
+            break;
+          case 'N':
+            vkCode = 'N';
+            break;
+          case 'O':
+            vkCode = 'O';
+            break;
+          case 'P':
+            vkCode = 'P';
+            break;
+          case 'Q':
+            vkCode = 'Q';
+            break;
+          case 'R':
+            vkCode = 'R';
+            break;
+          case 'S':
+            vkCode = 'S';
+            break;
+          case 'T':
+            vkCode = 'T';
+            break;
+          case 'U':
+            vkCode = 'U';
+            break;
+          case 'V':
+            vkCode = 'V';
+            break;
+          case 'W':
+            vkCode = 'W';
+            break;
+          case 'X':
+            vkCode = 'X';
+            break;
+          case 'Y':
+            vkCode = 'Y';
+            break;
+          case 'Z':
+            vkCode = 'Z';
+            break;
+          case '0':
+            vkCode = '0';
+            break;
+          case '1':
+            vkCode = '1';
+            break;
+          case '2':
+            vkCode = '2';
+            break;
+          case '3':
+            vkCode = '3';
+            break;
+          case '4':
+            vkCode = '4';
+            break;
+          case '5':
+            vkCode = '5';
+            break;
+          case '6':
+            vkCode = '6';
+            break;
+          case '7':
+            vkCode = '7';
+            break;
+          case '8':
+            vkCode = '8';
+            break;
+          case '9':
+            vkCode = '9';
+            break;
+          default:
+            break;// Key not recognized
+        }
+      }
+    }
+  }
+
+  if (vkCode != 0) {
+    inputs[inputCount].ki.wVk = LOBYTE(vkCode);
+    inputCount++;
+
+    // Now set up the key releases (in reverse order)
+    // First, release the key
+    inputs[inputCount] = inputs[inputCount - 1];
+    inputs[inputCount].ki.dwFlags = KEYEVENTF_KEYUP;
+    inputCount++;
+
+    // Then release modifiers in reverse order
+    for (int i = inputCount - 3; i >= 0; i--) {
+      inputs[inputCount] = inputs[i];
+      inputs[inputCount].ki.dwFlags = KEYEVENTF_KEYUP;
+      inputCount++;
+    }
+
+    // Send key events
+    UINT result = SendInput(inputCount, inputs, sizeof(INPUT));
+    if (result != inputCount) {
+      DWORD errorCode = GetLastError();
+      ESDDebug("SendInput failed with error: {}", errorCode);
+    }
+  }
+
+#elif defined(__APPLE__)
+  // macOS implementation using CGEventCreateKeyboardEvent
+  CGEventSourceRef source
+    = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+
+  // Get the key code for the specified key
+  CGKeyCode keyCode = 0;
+  // Basic mapping for common keys
+  if (hotkey.keyCode.length() == 1) {
+    char key = hotkey.keyCode[0];
+    if (key >= 'A' && key <= 'Z') {
+      // Map A-Z to macOS virtual key codes
+      keyCode = 0x00 + (key - 'A');// 'A' is 0x00, 'B' is 0x0B, etc.
+    }
+  } else if (
+    hotkey.keyCode.substr(0, 1) == "F" && hotkey.keyCode.length() <= 3) {
+    // Handle function keys F1-F12
+    int fKey = std::stoi(hotkey.keyCode.substr(1));
+    if (fKey >= 1 && fKey <= 12) {
+      static const CGKeyCode fKeyCodes[12] = {
+        0x7A, 0x78, 0x63, 0x76, 0x60, 0x61, 0x62, 0x64, 0x65, 0x6D, 0x67, 0x6F};
+      keyCode = fKeyCodes[fKey - 1];
+    }
+  }
+
+  if (keyCode != 0) {
+    // Create key down event
+    CGEventRef keyDownEvent = CGEventCreateKeyboardEvent(source, keyCode, true);
+
+    // Set modifiers
+    CGEventFlags flags = 0;
+    if (hotkey.ctrl)
+      flags |= kCGEventFlagMaskControl;
+    if (hotkey.alt)
+      flags |= kCGEventFlagMaskAlternate;
+    if (hotkey.shift)
+      flags |= kCGEventFlagMaskShift;
+    if (hotkey.win)
+      flags |= kCGEventFlagMaskCommand;
+
+    CGEventSetFlags(keyDownEvent, flags);
+
+    // Create key up event
+    CGEventRef keyUpEvent = CGEventCreateKeyboardEvent(source, keyCode, false);
+    CGEventSetFlags(keyUpEvent, flags);
+
+    // Post events
+    CGEventPost(kCGHIDEventTap, keyDownEvent);
+    usleep(10000);// Small delay
+    CGEventPost(kCGHIDEventTap, keyUpEvent);
+
+    // Release resources
+    CFRelease(keyDownEvent);
+    CFRelease(keyUpEvent);
+    CFRelease(source);
+  }
+#endif
 }

--- a/Sources/AudioSwitcherStreamDeckPlugin.cpp
+++ b/Sources/AudioSwitcherStreamDeckPlugin.cpp
@@ -134,12 +134,25 @@ void AudioSwitcherStreamDeckPlugin::KeyUpForAction(
     : settings.VolatileSecondaryID();
 
   if (deviceID.empty()) {
+    ESDDebug("Doing nothing, no device ID");
     return;
   }
 
   const auto deviceState = GetAudioDeviceState(deviceID);
   if (deviceState != AudioDeviceState::CONNECTED) {
+    if (inAction == SET_ACTION_ID) {
+      mConnectionManager->SetState(1, inContext);
+    }
     mConnectionManager->ShowAlertForContext(inContext);
+    return;
+  }
+
+  if (
+    inAction == SET_ACTION_ID
+    && deviceID == GetDefaultAudioDeviceID(settings.direction, settings.role)) {
+    // We already have the correct device, undo the state change
+    mConnectionManager->SetState(state, inContext);
+    ESDDebug("Already set, nothing to do");
     return;
   }
 

--- a/Sources/AudioSwitcherStreamDeckPlugin.h
+++ b/Sources/AudioSwitcherStreamDeckPlugin.h
@@ -87,3 +87,6 @@ class AudioSwitcherStreamDeckPlugin : public ESDBasePlugin {
   void UpdateState(const std::string& context, const std::string& device = "");
   void FillButtonDeviceInfo(const std::string& context);
 };
+
+// Function to trigger hotkeys with the given configuration
+void TriggerHotkey(const HotkeyConfig& hotkey);

--- a/Sources/ButtonSettings.cpp
+++ b/Sources/ButtonSettings.cpp
@@ -8,9 +8,13 @@
 
 #include <StreamDeckSDK/ESDLogger.h>
 
+#include <regex>
+
 #include "audio_json.h"
 
-#include <regex>
+// Forward declaration of FileLog for consistency with
+// AudioSwitcherStreamDeckPlugin.cpp
+// FileLog removed - no longer needed
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
   DeviceMatchStrategy,
@@ -18,6 +22,64 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
     {DeviceMatchStrategy::ID, "ID"},
     {DeviceMatchStrategy::Fuzzy, "Fuzzy"},
   });
+
+void from_json(const nlohmann::json& j, HotkeyConfig& hk) {
+  // Log all keys in the JSON for debugging
+  for (auto it = j.begin(); it != j.end(); ++it) {
+  }
+
+  if (j.contains("enabled")) {
+    hk.enabled = j.at("enabled");
+  } else if (j.contains("hotkeyEnabled")) {
+    // For backward compatibility
+    hk.enabled = j.at("hotkeyEnabled");
+  }
+
+  if (j.contains("ctrl")) {
+    hk.ctrl = j.at("ctrl");
+  } else if (j.contains("hotkeyCtrl")) {
+    // For backward compatibility
+    hk.ctrl = j.at("hotkeyCtrl");
+  }
+
+  if (j.contains("alt")) {
+    hk.alt = j.at("alt");
+  } else if (j.contains("hotkeyAlt")) {
+    // For backward compatibility
+    hk.alt = j.at("hotkeyAlt");
+  }
+
+  if (j.contains("shift")) {
+    hk.shift = j.at("shift");
+  } else if (j.contains("hotkeyShift")) {
+    // For backward compatibility
+    hk.shift = j.at("hotkeyShift");
+  }
+
+  if (j.contains("win")) {
+    hk.win = j.at("win");
+  } else if (j.contains("hotkeyWin")) {
+    // For backward compatibility
+    hk.win = j.at("hotkeyWin");
+  }
+
+  if (j.contains("keyCode")) {
+    hk.keyCode = j.at("keyCode");
+  } else if (j.contains("hotkeyKey")) {
+    // For backward compatibility
+    hk.keyCode = j.at("hotkeyKey");
+  }
+}
+
+void to_json(nlohmann::json& j, const HotkeyConfig& hk) {
+  j = {
+    {"enabled", hk.enabled},
+    {"ctrl", hk.ctrl},
+    {"alt", hk.alt},
+    {"shift", hk.shift},
+    {"win", hk.win},
+    {"keyCode", hk.keyCode}};
+}
 
 void from_json(const nlohmann::json& j, ButtonSettings& bs) {
   if (!j.contains("direction")) {
@@ -51,6 +113,17 @@ void from_json(const nlohmann::json& j, ButtonSettings& bs) {
   if (j.contains("matchStrategy")) {
     bs.matchStrategy = j.at("matchStrategy");
   }
+
+  if (j.contains("primaryHotkey")) {
+    bs.primaryHotkey = j.at("primaryHotkey");
+  } else if (j.contains("hotkey")) {
+    // For backward compatibility
+    bs.primaryHotkey = j.at("hotkey");
+  }
+
+  if (j.contains("secondaryHotkey")) {
+    bs.secondaryHotkey = j.at("secondaryHotkey");
+  }
 }
 
 void to_json(nlohmann::json& j, const ButtonSettings& bs) {
@@ -60,18 +133,19 @@ void to_json(nlohmann::json& j, const ButtonSettings& bs) {
     {"primary", bs.primaryDevice},
     {"secondary", bs.secondaryDevice},
     {"matchStrategy", bs.matchStrategy},
-  };
+    {"primaryHotkey", bs.primaryHotkey},
+    {"secondaryHotkey", bs.secondaryHotkey}};
 }
 
 namespace {
 
 std::string FuzzifyInterface(const std::string& name) {
   // Windows likes to replace "Foo" with "2- Foo"
-  const std::regex pattern {"^([0-9]+- )?(.+)$"};
+  const std::regex pattern{"^([0-9]+- )?(.+)$"};
   std::smatch captures;
   if (!std::regex_match(name, captures, pattern)) {
     return name;
-  } 
+  }
   return captures[2];
 }
 
@@ -91,7 +165,10 @@ std::string GetVolatileID(
   }
 
   const auto fuzzyInterface = FuzzifyInterface(device.interfaceName);
-  ESDDebug("Looking for a fuzzy match: {} -> {}", device.interfaceName, fuzzyInterface);
+  ESDDebug(
+    "Looking for a fuzzy match: {} -> {}",
+    device.interfaceName,
+    fuzzyInterface);
 
   for (const auto& [otherID, other] : GetAudioDeviceList(device.direction)) {
     if (other.state != AudioDeviceState::CONNECTED) {

--- a/Sources/ButtonSettings.h
+++ b/Sources/ButtonSettings.h
@@ -16,12 +16,23 @@ enum class DeviceMatchStrategy {
   Fuzzy,
 };
 
+struct HotkeyConfig {
+  bool enabled = false;
+  bool ctrl = false;
+  bool alt = false;
+  bool shift = false;
+  bool win = false;// Command key on macOS
+  std::string keyCode = "";// Key identifier
+};
+
 struct ButtonSettings {
   AudioDeviceDirection direction = AudioDeviceDirection::INPUT;
   AudioDeviceRole role = AudioDeviceRole::DEFAULT;
   AudioDeviceInfo primaryDevice;
   AudioDeviceInfo secondaryDevice;
   DeviceMatchStrategy matchStrategy = DeviceMatchStrategy::ID;
+  HotkeyConfig primaryHotkey;
+  HotkeyConfig secondaryHotkey;
 
   // Changes if there's a fuzzy match
   std::string VolatilePrimaryID() const;

--- a/sdPlugin/propertyinspector/index.html
+++ b/sdPlugin/propertyinspector/index.html
@@ -58,6 +58,162 @@
         <option value="Fuzzy">Fuzzy</option>
       </select>
     </div>
+    
+    <div type="checkbox" class="sdpi-item">
+      <div class="sdpi-item-label">Primary Hotkey</div>
+      <div class="sdpi-item-value">
+        <span class="sdpi-item-child">
+          <input id="primaryHotkeyEnabled" type="checkbox" onchange="updateHotkey('primary');" />
+          <label for="primaryHotkeyEnabled" class="sdpi-item-label"><span></span>Enable</label>
+        </span>
+      </div>
+    </div>
+
+    <div id="primaryHotkeyConfigDiv" class="sdpi-item" style="display: none;">
+      <div class="sdpi-item-label">Primary Hotkey</div>
+      <div class="sdpi-item-value">
+        <div class="sdpi-item-child">
+          <span class="sdpi-item-child">
+            <input id="primaryHotkeyCtrl" type="checkbox" onchange="saveSettings();" />
+            <label for="primaryHotkeyCtrl" class="sdpi-item-label"><span></span>Ctrl</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="primaryHotkeyAlt" type="checkbox" onchange="saveSettings();" />
+            <label for="primaryHotkeyAlt" class="sdpi-item-label"><span></span>Alt</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="primaryHotkeyShift" type="checkbox" onchange="saveSettings();" />
+            <label for="primaryHotkeyShift" class="sdpi-item-label"><span></span>Shift</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="primaryHotkeyWin" type="checkbox" onchange="saveSettings();" />
+            <label for="primaryHotkeyWin" class="sdpi-item-label"><span></span>Win/Cmd</label>
+          </span>
+        </div>
+        <div class="sdpi-item-child">
+          <select class="sdpi-item-value select" id="primaryHotkeyKey" onchange="saveSettings();">
+            <!-- Common keys -->
+            <option value="">Select a key...</option>
+            <option value="A">A</option>
+            <option value="B">B</option>
+            <option value="C">C</option>
+            <option value="D">D</option>
+            <option value="E">E</option>
+            <option value="F">F</option>
+            <option value="G">G</option>
+            <option value="H">H</option>
+            <option value="I">I</option>
+            <option value="J">J</option>
+            <option value="K">K</option>
+            <option value="L">L</option>
+            <option value="M">M</option>
+            <option value="N">N</option>
+            <option value="O">O</option>
+            <option value="P">P</option>
+            <option value="Q">Q</option>
+            <option value="R">R</option>
+            <option value="S">S</option>
+            <option value="T">T</option>
+            <option value="U">U</option>
+            <option value="V">V</option>
+            <option value="W">W</option>
+            <option value="X">X</option>
+            <option value="Y">Y</option>
+            <option value="Z">Z</option>
+            <option value="F1">F1</option>
+            <option value="F2">F2</option>
+            <option value="F3">F3</option>
+            <option value="F4">F4</option>
+            <option value="F5">F5</option>
+            <option value="F6">F6</option>
+            <option value="F7">F7</option>
+            <option value="F8">F8</option>
+            <option value="F9">F9</option>
+            <option value="F10">F10</option>
+            <option value="F11">F11</option>
+            <option value="F12">F12</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div type="checkbox" class="sdpi-item" id="secondaryHotkeyDiv">
+      <div class="sdpi-item-label">Secondary Hotkey</div>
+      <div class="sdpi-item-value">
+        <span class="sdpi-item-child">
+          <input id="secondaryHotkeyEnabled" type="checkbox" onchange="updateHotkey('secondary');" />
+          <label for="secondaryHotkeyEnabled" class="sdpi-item-label"><span></span>Enable</label>
+        </span>
+      </div>
+    </div>
+
+    <div id="secondaryHotkeyConfigDiv" class="sdpi-item" style="display: none;">
+      <div class="sdpi-item-label">Secondary Hotkey</div>
+      <div class="sdpi-item-value">
+        <div class="sdpi-item-child">
+          <span class="sdpi-item-child">
+            <input id="secondaryHotkeyCtrl" type="checkbox" onchange="saveSettings();" />
+            <label for="secondaryHotkeyCtrl" class="sdpi-item-label"><span></span>Ctrl</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="secondaryHotkeyAlt" type="checkbox" onchange="saveSettings();" />
+            <label for="secondaryHotkeyAlt" class="sdpi-item-label"><span></span>Alt</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="secondaryHotkeyShift" type="checkbox" onchange="saveSettings();" />
+            <label for="secondaryHotkeyShift" class="sdpi-item-label"><span></span>Shift</label>
+          </span>
+          <span class="sdpi-item-child">
+            <input id="secondaryHotkeyWin" type="checkbox" onchange="saveSettings();" />
+            <label for="secondaryHotkeyWin" class="sdpi-item-label"><span></span>Win/Cmd</label>
+          </span>
+        </div>
+        <div class="sdpi-item-child">
+          <select class="sdpi-item-value select" id="secondaryHotkeyKey" onchange="saveSettings();">
+            <!-- Common keys -->
+            <option value="">Select a key...</option>
+            <option value="A">A</option>
+            <option value="B">B</option>
+            <option value="C">C</option>
+            <option value="D">D</option>
+            <option value="E">E</option>
+            <option value="F">F</option>
+            <option value="G">G</option>
+            <option value="H">H</option>
+            <option value="I">I</option>
+            <option value="J">J</option>
+            <option value="K">K</option>
+            <option value="L">L</option>
+            <option value="M">M</option>
+            <option value="N">N</option>
+            <option value="O">O</option>
+            <option value="P">P</option>
+            <option value="Q">Q</option>
+            <option value="R">R</option>
+            <option value="S">S</option>
+            <option value="T">T</option>
+            <option value="U">U</option>
+            <option value="V">V</option>
+            <option value="W">W</option>
+            <option value="X">X</option>
+            <option value="Y">Y</option>
+            <option value="Z">Z</option>
+            <option value="F1">F1</option>
+            <option value="F2">F2</option>
+            <option value="F3">F3</option>
+            <option value="F4">F4</option>
+            <option value="F5">F5</option>
+            <option value="F6">F6</option>
+            <option value="F7">F7</option>
+            <option value="F8">F8</option>
+            <option value="F9">F9</option>
+            <option value="F10">F10</option>
+            <option value="F11">F11</option>
+            <option value="F12">F12</option>
+          </select>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="common.js"></script>
@@ -102,6 +258,52 @@
         } else {
           child.removeAttribute("selected");
         }
+      }
+      
+      // Initialize primary hotkey UI elements
+      const primaryHotkey = settings.primaryHotkey || settings.hotkey || {};
+      const primaryHotkeyEnabled = primaryHotkey.enabled || false;
+      document.getElementById('primaryHotkeyEnabled').checked = primaryHotkeyEnabled;
+      document.getElementById('primaryHotkeyConfigDiv').style.display = primaryHotkeyEnabled ? 'flex' : 'none';
+      
+      document.getElementById('primaryHotkeyCtrl').checked = primaryHotkey.ctrl || false;
+      document.getElementById('primaryHotkeyAlt').checked = primaryHotkey.alt || false;
+      document.getElementById('primaryHotkeyShift').checked = primaryHotkey.shift || false;
+      document.getElementById('primaryHotkeyWin').checked = primaryHotkey.win || false;
+      
+      const primaryHotkeyKey = primaryHotkey.keyCode || "";
+      for (const child of document.getElementById('primaryHotkeyKey').children) {
+        if (child.value == primaryHotkeyKey) {
+          child.setAttribute("selected", "selected");
+        } else {
+          child.removeAttribute("selected");
+        }
+      }
+
+      // Initialize secondary hotkey UI elements
+      const secondaryHotkey = settings.secondaryHotkey || {};
+      const secondaryHotkeyEnabled = secondaryHotkey.enabled || false;
+      document.getElementById('secondaryHotkeyEnabled').checked = secondaryHotkeyEnabled;
+      document.getElementById('secondaryHotkeyConfigDiv').style.display = secondaryHotkeyEnabled ? 'flex' : 'none';
+      
+      document.getElementById('secondaryHotkeyCtrl').checked = secondaryHotkey.ctrl || false;
+      document.getElementById('secondaryHotkeyAlt').checked = secondaryHotkey.alt || false;
+      document.getElementById('secondaryHotkeyShift').checked = secondaryHotkey.shift || false;
+      document.getElementById('secondaryHotkeyWin').checked = secondaryHotkey.win || false;
+      
+      const secondaryHotkeyKey = secondaryHotkey.keyCode || "";
+      for (const child of document.getElementById('secondaryHotkeyKey').children) {
+        if (child.value == secondaryHotkeyKey) {
+          child.setAttribute("selected", "selected");
+        } else {
+          child.removeAttribute("selected");
+        }
+      }
+
+      // Hide secondary hotkey controls for "set" action
+      if (actionInfo == "com.fredemmott.audiooutputswitch.set") {
+        document.getElementById('secondaryHotkeyDiv').style.display = 'none';
+        document.getElementById('secondaryHotkeyConfigDiv').style.display = 'none';
       }
 
       inputDevices = payload['inputDevices'];
@@ -229,11 +431,19 @@
       if (actionInfo == "com.fredemmott.audiooutputswitch.set") {
         document.querySelector('#primaryDeviceDiv .sdpi-item-label').innerText = 'Device';
         document.getElementById('secondaryDeviceDiv').style.display = 'none';
+        document.getElementById('secondaryHotkeyDiv').style.display = 'none';
+        document.getElementById('secondaryHotkeyConfigDiv').style.display = 'none';
       }
 
       // request settings and list of devices
       $SD.api.sendToPlugin(uuid, actionInfo, { event: "getDeviceList" });
     };
+
+    function updateHotkey(device) {
+      const hotkeyEnabled = document.getElementById(`${device}HotkeyEnabled`).checked;
+      document.getElementById(`${device}HotkeyConfigDiv`).style.display = hotkeyEnabled ? 'flex' : 'none';
+      saveSettings();
+    }
 
     function saveSettings() {
       const isInput = document.getElementById('input').checked;
@@ -247,6 +457,37 @@
       settings.direction = isInput ? 'input' : 'output';
       settings.role = document.getElementById('defaultRole').checked ? 'default' : 'communication';
       settings.matchStrategy = document.getElementById('matchStrategy').value;
+      
+      // Save primary hotkey configuration
+      settings.primaryHotkey = {
+        enabled: document.getElementById('primaryHotkeyEnabled').checked,
+        ctrl: document.getElementById('primaryHotkeyCtrl').checked,
+        alt: document.getElementById('primaryHotkeyAlt').checked,
+        shift: document.getElementById('primaryHotkeyShift').checked,
+        win: document.getElementById('primaryHotkeyWin').checked,
+        keyCode: document.getElementById('primaryHotkeyKey').value
+      };
+      
+      // For backward compatibility
+      settings.hotkey = {
+        enabled: document.getElementById('primaryHotkeyEnabled').checked,
+        ctrl: document.getElementById('primaryHotkeyCtrl').checked,
+        alt: document.getElementById('primaryHotkeyAlt').checked,
+        shift: document.getElementById('primaryHotkeyShift').checked,
+        win: document.getElementById('primaryHotkeyWin').checked,
+        keyCode: document.getElementById('primaryHotkeyKey').value
+      };
+      
+      // Save secondary hotkey configuration
+      settings.secondaryHotkey = {
+        enabled: document.getElementById('secondaryHotkeyEnabled').checked,
+        ctrl: document.getElementById('secondaryHotkeyCtrl').checked,
+        alt: document.getElementById('secondaryHotkeyAlt').checked,
+        shift: document.getElementById('secondaryHotkeyShift').checked,
+        win: document.getElementById('secondaryHotkeyWin').checked,
+        keyCode: document.getElementById('secondaryHotkeyKey').value
+      };
+      
       console.log(settings);
       $SD.api.setSettings(uuid, settings);
     }


### PR DESCRIPTION
**Feature: Hotkey Support When Switching Audio Devices**
This PR adds the ability to trigger custom keyboard shortcuts when switching between audio devices, enhancing the plugin's functionality for users who want to automate additional actions when changing audio outputs or inputs. For instance, I use it to trigger shortcuts within Peace Equalizer to swap configurations to match my audio output device.

**Changes:**

Added hotkey configuration UI to Property Inspector
Implemented platform-specific hotkey simulation for Windows and macOS
Added support for modifier keys (Ctrl, Alt, Shift, Win/Cmd) and common keyboard keys
Extended settings storage to preserve hotkey configurations

**Testing:**

Tested all functionality on Windows
Feature is implemented for both macOS and Windows, but was unable to test macOS.

This feature was added without changing the core audio switching functionality, so existing users' workflows remain intact.

Edit: didn't realize it needed a signature, sorry! Happy to address it if needed.